### PR TITLE
Fix docstring typos

### DIFF
--- a/app/pipelines/fcl_main_rates_v1/pipeline.py
+++ b/app/pipelines/fcl_main_rates_v1/pipeline.py
@@ -28,7 +28,7 @@ def fetch_all_records(
     limit: int = 0,
     offset: int = 0,
 ):
-    """Fetch records in batches and validate them against the Avro schema."""
+    """Continuously polls data by calling fetch_records and validates it against the Avro schema."""
     schema = parse_schema(schema)
 
     while True:


### PR DESCRIPTION
## Summary
- correct typos in the `fetch_all_records` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684002b7d8a8832d87f54e3e356ccc36