### PR TITLE
Clarify batch behavior in pipeline docstring

### DIFF
--- a/app/pipelines/fcl_main_rates_v1/pipeline.py
+++ b/app/pipelines/fcl_main_rates_v1/pipeline.py
@@ -28,7 +28,12 @@ def fetch_all_records(
     limit: int = 0,
     offset: int = 0,
 ):
-    """Fetch records in batches and validate them against the Avro schema."""
+    """Fetch all matching records in batches and validate them.
+
+    The function keeps pulling batches of size ``limit`` starting from
+    ``offset`` and validates them against the Avro schema until no
+    additional records are returned.
+    """
     schema = parse_schema(schema)
 
     while True:


### PR DESCRIPTION
## Summary
- update docstring in `fetch_all_records` to clearly state it loops over batches

## Testing
- `python -m py_compile app/pipelines/fcl_main_rates_v1/pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684002b376a4832da92e8bdc153321a3